### PR TITLE
Update jaxws-spring

### DIFF
--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <groupId>net.java</groupId>
         <artifactId>jvnet-parent</artifactId>
-        <version>4</version>
+        <version>5</version>
     </parent>
   
     <groupId>org.jvnet.jax-ws-commons</groupId>
@@ -125,10 +125,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.2</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
                         <!--

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jvnet.jax-ws-commons</groupId>
     <artifactId>pom</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
     <relativePath>../pom/pom.xml</relativePath>
   </parent>
 
@@ -25,10 +25,6 @@
     <url>https://java.net/jira/browse/JAX_WS_COMMONS</url>
   </issueManagement>
 
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
 
   <build>
     <plugins>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -25,6 +25,11 @@
     <url>https://java.net/jira/browse/JAX_WS_COMMONS</url>
   </issueManagement>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/spring/spring-core/pom.xml
+++ b/spring/spring-core/pom.xml
@@ -15,9 +15,9 @@
   <description>Configure JAX-WS with Spring</description>
 
   <properties>
-    <jax-ws-version>2.2.8</jax-ws-version>
-    <metro-version>2.2.8-promoted-b146</metro-version>
-    <spring-version>3.2.3.RELEASE</spring-version>
+    <jax-ws-version>2.3.1</jax-ws-version>
+    <metro-version>2.3.1</metro-version>
+    <spring-version>4.3.22.RELEASE</spring-version>
     <xbean-version>3.14</xbean-version>
   </properties>
 
@@ -129,6 +129,13 @@
           </reportPlugins>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -139,14 +146,14 @@
       <version>${jax-ws-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.ws</groupId>
-      <artifactId>jaxws-rt</artifactId>
+      <groupId>org.glassfish.metro</groupId>
+      <artifactId>webservices-rt</artifactId>
       <version>${metro-version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-local-transport</artifactId>
-      <version>${metro-version}</version>
+      <version>${jax-ws-version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -182,7 +189,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <!-- shouldn't be needed once JAX-WS RT POM properly declares the dependency -->

--- a/spring/spring-core/pom.xml
+++ b/spring/spring-core/pom.xml
@@ -129,13 +129,6 @@
           </reportPlugins>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -192,21 +185,6 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-    <!-- shouldn't be needed once JAX-WS RT POM properly declares the dependency -->
-    <dependency>
-      <groupId>javax.jws</groupId>
-      <artifactId>jsr181-api</artifactId>
-      <version>1.0-MR1</version>
-    </dependency>
   </dependencies>
 
-  <!-- sorcerer needs Mustang, but Mustang won't work with JAXB/WS 2.1
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.jvnet.sorcerer</groupId>
-        <artifactId>maven-sorcerer-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>-->
 </project>

--- a/spring/spring-core/src/main/java/org/jvnet/jax_ws_commons/spring/SpringService.java
+++ b/spring/spring-core/src/main/java/org/jvnet/jax_ws_commons/spring/SpringService.java
@@ -35,7 +35,6 @@
  */
 package org.jvnet.jax_ws_commons.spring;
 
-import com.sun.istack.NotNull;
 import com.sun.xml.ws.api.BindingID;
 import com.sun.xml.ws.api.WSBinding;
 import com.sun.xml.ws.api.pipe.TubelineAssembler;
@@ -79,7 +78,6 @@ import java.util.ArrayList;
 // javadoc for this class is used to auto-generate documentation.
 public class SpringService implements FactoryBean<WSEndpoint>, ServletContextAware, InitializingBean {
 
-    @NotNull
     private Class<?> implType;
 
     // everything else can be null
@@ -531,7 +529,7 @@ public class SpringService implements FactoryBean<WSEndpoint>, ServletContextAwa
         private final Module module = new Module() {
             private final List<BoundEndpoint> endpoints = new ArrayList<BoundEndpoint>();
 
-            public @NotNull List<BoundEndpoint> getBoundEndpoints() {
+            public List<BoundEndpoint> getBoundEndpoints() {
                 return endpoints;
             }
         };

--- a/spring/test-app/pom.xml
+++ b/spring/test-app/pom.xml
@@ -17,7 +17,14 @@
     <finalName>${project.artifactId}</finalName>
     
     <plugins>
-      <plugin> 
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.mortbay.jetty</groupId> 
         <artifactId>maven-jetty-plugin</artifactId>
         <version>6.1.26</version>
@@ -49,7 +56,7 @@
     <dependency>
       <groupId>org.jvnet.jax-ws-commons.spring</groupId>
       <artifactId>jaxws-spring</artifactId>
-      <version>${version}</version>
+      <version>${project.version}</version>
     </dependency>
     <!--
       for this test to run correctly we need more recent SJSXP,

--- a/spring/test-app/pom.xml
+++ b/spring/test-app/pom.xml
@@ -18,13 +18,6 @@
     
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.mortbay.jetty</groupId> 
         <artifactId>maven-jetty-plugin</artifactId>
         <version>6.1.26</version>
@@ -33,21 +26,6 @@
           <scanIntervalSeconds>1</scanIntervalSeconds>
         </configuration>
       </plugin>
-      <!--plugin>
-        <groupId>eviware</groupId>
-        <artifactId>maven-soapui-plugin</artifactId>
-        <version>1.0-beta1</version>
-        <executions>
-          <execution>
-            <id>ui-test</id>
-            <phase>test</phase>
-            <configuration>
-              <projectFile>soapui.xml</projectFile>
-              <host>http://localhost:8080/</host>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin-->
     </plugins>
   </build>
   
@@ -58,16 +36,6 @@
       <artifactId>jaxws-spring</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!--
-      for this test to run correctly we need more recent SJSXP,
-      but having that dependency prevents our release. So this
-      is commented out.
-    -->
-    <!--dependency>
-      <groupId>com.sun.xml.stream</groupId>
-      <artifactId>sjsxp</artifactId>
-      <version>SNAPSHOT</version>
-    </dependency-->
   </dependencies>
   
   <pluginRepositories>


### PR DESCRIPTION
Replaced jaxws-rt with webservices-rt, due to a vulnerability in ha-api.
Upgraded spring framework version and other dependencies